### PR TITLE
Add support for M2tsVideo in ClicsModel

### DIFF
--- a/schemas/advanced.schema.json
+++ b/schemas/advanced.schema.json
@@ -1,6 +1,27 @@
 {
     "$ref": "#/$defs/ICPC live advanced settings",
     "$defs": {
+        "M2tsVideo": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "const": "M2tsVideo",
+                    "default": "M2tsVideo"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "isMedia": {
+                    "type": "boolean"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "type",
+                "url"
+            ],
+            "title": "M2tsVideo"
+        },
         "Object": {
             "type": "object",
             "properties": {
@@ -144,6 +165,9 @@
         },
         "org.icpclive.cds.api.MediaType?<kotlin.String,kotlinx.serialization.Sealed<MediaType>>": {
             "oneOf": [
+                {
+                    "$ref": "#/$defs/M2tsVideo"
+                },
                 {
                     "$ref": "#/$defs/Object"
                 },

--- a/src/cds-converter/src/main/kotlin/org/icpclive/export/clics/ClicsExporter.kt
+++ b/src/cds-converter/src/main/kotlin/org/icpclive/export/clics/ClicsExporter.kt
@@ -50,6 +50,7 @@ private fun MediaType.toClicsMedia() = when (this) {
     is MediaType.Photo -> Media("image", url)
     is MediaType.TaskStatus -> null
     is MediaType.Video -> Media("video", url)
+    is MediaType.M2tsVideo -> Media("video", url)
     is MediaType.WebRTCGrabberConnection -> null
     is MediaType.WebRTCProxyConnection -> null
 }

--- a/src/cds-converter/src/main/kotlin/org/icpclive/export/clics/ClicsExporter.kt
+++ b/src/cds-converter/src/main/kotlin/org/icpclive/export/clics/ClicsExporter.kt
@@ -50,7 +50,7 @@ private fun MediaType.toClicsMedia() = when (this) {
     is MediaType.Photo -> Media("image", url)
     is MediaType.TaskStatus -> null
     is MediaType.Video -> Media("video", url)
-    is MediaType.M2tsVideo -> Media("video", url)
+    is MediaType.M2tsVideo -> Media("video/m2ts", url)
     is MediaType.WebRTCGrabberConnection -> null
     is MediaType.WebRTCProxyConnection -> null
 }

--- a/src/cds/core/api/core.api
+++ b/src/cds/core/api/core.api
@@ -747,6 +747,36 @@ public final class org/icpclive/cds/api/MediaType$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class org/icpclive/cds/api/MediaType$M2tsVideo : org/icpclive/cds/api/MediaType {
+	public static final field Companion Lorg/icpclive/cds/api/MediaType$M2tsVideo$Companion;
+	public fun <init> (Ljava/lang/String;Z)V
+	public synthetic fun <init> (Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Z
+	public final fun copy (Ljava/lang/String;Z)Lorg/icpclive/cds/api/MediaType$M2tsVideo;
+	public static synthetic fun copy$default (Lorg/icpclive/cds/api/MediaType$M2tsVideo;Ljava/lang/String;ZILjava/lang/Object;)Lorg/icpclive/cds/api/MediaType$M2tsVideo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun isMedia ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class org/icpclive/cds/api/MediaType$M2tsVideo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lorg/icpclive/cds/api/MediaType$M2tsVideo$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lorg/icpclive/cds/api/MediaType$M2tsVideo;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lorg/icpclive/cds/api/MediaType$M2tsVideo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class org/icpclive/cds/api/MediaType$M2tsVideo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class org/icpclive/cds/api/MediaType$Object : org/icpclive/cds/api/MediaType {
 	public static final field Companion Lorg/icpclive/cds/api/MediaType$Object$Companion;
 	public fun <init> (Ljava/lang/String;Z)V

--- a/src/cds/core/src/main/kotlin/org/icpclive/cds/adapters/AdvancedPropertiesAdapter.kt
+++ b/src/cds/core/src/main/kotlin/org/icpclive/cds/adapters/AdvancedPropertiesAdapter.kt
@@ -39,7 +39,7 @@ private fun urlEncoded(block: (String) -> String?) : (String) -> String? = l@{
 private fun MediaType.applyTemplate(valueProvider: (String) -> String?) = when (this) {
     is MediaType.Photo -> copy(url = url.applyTemplate(urlEncoded(valueProvider)))
     is MediaType.Video -> copy(url = url.applyTemplate(urlEncoded(valueProvider)))
-    is MediaType.M2tsVideo -> copy(url = url.applyTemplate(valueProvider))
+    is MediaType.M2tsVideo -> copy(url = url.applyTemplate(urlEncoded(valueProvider)))
     is MediaType.Object -> copy(url = url.applyTemplate(urlEncoded(valueProvider)))
     is MediaType.WebRTCProxyConnection -> copy(url = url.applyTemplate(urlEncoded(valueProvider)))
     is MediaType.WebRTCGrabberConnection -> copy(

--- a/src/cds/core/src/main/kotlin/org/icpclive/cds/adapters/AdvancedPropertiesAdapter.kt
+++ b/src/cds/core/src/main/kotlin/org/icpclive/cds/adapters/AdvancedPropertiesAdapter.kt
@@ -39,6 +39,7 @@ private fun urlEncoded(block: (String) -> String?) : (String) -> String? = l@{
 private fun MediaType.applyTemplate(valueProvider: (String) -> String?) = when (this) {
     is MediaType.Photo -> copy(url = url.applyTemplate(urlEncoded(valueProvider)))
     is MediaType.Video -> copy(url = url.applyTemplate(urlEncoded(valueProvider)))
+    is MediaType.M2tsVideo -> copy(url = url.applyTemplate(valueProvider))
     is MediaType.Object -> copy(url = url.applyTemplate(urlEncoded(valueProvider)))
     is MediaType.WebRTCProxyConnection -> copy(url = url.applyTemplate(urlEncoded(valueProvider)))
     is MediaType.WebRTCGrabberConnection -> copy(

--- a/src/cds/core/src/main/kotlin/org/icpclive/cds/api/ContestInfo.kt
+++ b/src/cds/core/src/main/kotlin/org/icpclive/cds/api/ContestInfo.kt
@@ -89,6 +89,10 @@ public sealed class MediaType {
     @SerialName("Video")
     public data class Video(val url: String, override val isMedia: Boolean = true) : MediaType()
 
+    @Serializable
+    @SerialName("M2tsVideo")
+    public data class M2tsVideo(val url: String, override val isMedia: Boolean = true) : MediaType()
+
     /**
      * WebRTC proxy connection
      * @see <a href="https://github.com/kbats183/webrtc-proxy">https://github.com/kbats183/webrtc-proxy</a>
@@ -126,6 +130,7 @@ public sealed class MediaType {
         is Photo -> copy(isMedia = false)
         is Video -> copy(isMedia = false)
         is Object -> copy(isMedia = false)
+        is M2tsVideo -> copy(isMedia = false)
         is WebRTCProxyConnection -> copy(isMedia = false)
         is WebRTCGrabberConnection -> copy(isMedia = false)
         else -> this

--- a/src/cds/plugins/clics/src/main/kotlin/org/icpclive/cds/plugins/clics/ClicsModel.kt
+++ b/src/cds/plugins/clics/src/main/kotlin/org/icpclive/cds/plugins/clics/ClicsModel.kt
@@ -46,6 +46,9 @@ internal class ClicsModel(private val addTeamNames: Boolean) {
         if (mime.startsWith("image")) {
             return MediaType.Photo(href)
         }
+        if (mime.startsWith("video/m2ts")) {
+            return MediaType.M2tsVideo(href)
+        }
         if (mime.startsWith("video")) {
             return MediaType.Video(href)
         }

--- a/src/frontend/common/api.ts
+++ b/src/frontend/common/api.ts
@@ -98,23 +98,29 @@ export enum ScoreMergeMode {
 }
 
 export type MediaType =
+  | MediaType.M2tsVideo
   | MediaType.Object
   | MediaType.Photo
   | MediaType.TaskStatus
   | MediaType.Video
-  | MediaType.M2tsVideo
   | MediaType.WebRTCGrabberConnection
   | MediaType.WebRTCProxyConnection;
 
 export namespace MediaType {
   export enum Type {
+    M2tsVideo = "M2tsVideo",
     Object = "Object",
     Photo = "Photo",
     TaskStatus = "TaskStatus",
     Video = "Video",
-    M2tsVideo = "M2tsVideo",
     WebRTCGrabberConnection = "WebRTCGrabberConnection",
     WebRTCProxyConnection = "WebRTCProxyConnection",
+  }
+  
+  export interface M2tsVideo {
+    type: MediaType.Type.M2tsVideo;
+    url: string;
+    isMedia?: boolean;
   }
   
   export interface Object {
@@ -137,12 +143,6 @@ export namespace MediaType {
   
   export interface Video {
     type: MediaType.Type.Video;
-    url: string;
-    isMedia?: boolean;
-  }
-
-  export interface M2tsVideo {
-    type: MediaType.Type.M2tsVideo;
     url: string;
     isMedia?: boolean;
   }

--- a/src/frontend/common/api.ts
+++ b/src/frontend/common/api.ts
@@ -102,6 +102,7 @@ export type MediaType =
   | MediaType.Photo
   | MediaType.TaskStatus
   | MediaType.Video
+  | MediaType.M2tsVideo
   | MediaType.WebRTCGrabberConnection
   | MediaType.WebRTCProxyConnection;
 
@@ -111,6 +112,7 @@ export namespace MediaType {
     Photo = "Photo",
     TaskStatus = "TaskStatus",
     Video = "Video",
+    M2tsVideo = "M2tsVideo",
     WebRTCGrabberConnection = "WebRTCGrabberConnection",
     WebRTCProxyConnection = "WebRTCProxyConnection",
   }
@@ -135,6 +137,12 @@ export namespace MediaType {
   
   export interface Video {
     type: MediaType.Type.Video;
+    url: string;
+    isMedia?: boolean;
+  }
+
+  export interface M2tsVideo {
+    type: MediaType.Type.M2tsVideo;
     url: string;
     isMedia?: boolean;
   }

--- a/src/frontend/overlay/package.json
+++ b/src/frontend/overlay/package.json
@@ -8,6 +8,7 @@
     "@vitejs/plugin-react": "^4.0.3",
     "lodash": "^4.17.21",
     "luxon": "^2.3.1",
+    "mpegts.js": "^1.7.3",
     "prop-types": "^15.7.2",
     "react": "^17.0.2",
     "react-components": "^0.5.1",

--- a/src/frontend/overlay/src/components/organisms/holder/ContestantViewHolder.tsx
+++ b/src/frontend/overlay/src/components/organisms/holder/ContestantViewHolder.tsx
@@ -31,7 +31,7 @@ export const VideoWrapper = styled.video`
 
 export const TeamM2tsVideoWrapper = ({ url, setIsLoaded }) => {
     const dispatch = useAppDispatch();
-    const videoRef = useRef();
+    const videoRef = useRef<HTMLVideoElement>();
     useEffect(() => {
         setIsLoaded(false);
         if (videoRef.current) {
@@ -46,7 +46,11 @@ export const TeamM2tsVideoWrapper = ({ url, setIsLoaded }) => {
                 player.destroy();
             };
         }
-        return () => {};
+        return ()  => {
+            if (videoRef.current) {
+                videoRef.current.srcObject = null;
+            }
+        }
     }, [url]);
     return (<VideoWrapper
         ref={videoRef}

--- a/src/frontend/overlay/src/components/organisms/holder/ContestantViewHolder.tsx
+++ b/src/frontend/overlay/src/components/organisms/holder/ContestantViewHolder.tsx
@@ -6,6 +6,7 @@ import { GrabberPlayerClient } from "../../../utils/grabber/grabber_player";
 import { useAppDispatch } from "@/redux/hooks";
 import { MediaType } from "@shared/api";
 import c from "../../../config";
+import mpegts from "mpegts.js";
 
 // export const TeamImageWrapper = styled.img /*`
 //   // border-radius: ${({ borderRadius }) => borderRadius};
@@ -27,6 +28,38 @@ export const VideoWrapper = styled.video`
   width: 100%;
   border-radius: ${c.GLOBAL_BORDER_RADIUS};
 `;
+
+export const TeamM2tsVideoWrapper = ({ url, setIsLoaded }) => {
+    const dispatch = useAppDispatch();
+    const videoRef = useRef();
+    useEffect(() => {
+        setIsLoaded(false);
+        if (videoRef.current) {
+            const player = mpegts.createPlayer({
+                type: "mpegts",
+                isLive: true,
+                url: url,
+            });
+            player.attachMediaElement(videoRef.current);
+            player.load();
+            return () => {
+                player.destroy();
+            };
+        }
+        return () => {};
+    }, [url]);
+    return (<VideoWrapper
+        ref={videoRef}
+        onError={() => setIsLoaded(false) || dispatch(pushLog("ERROR on loading image in Picture widget"))}
+        onLoadedData={() =>
+            // console.log("Loaded");
+            // console.log(videoRef.current.currentTime);
+            setIsLoaded(true)
+        }
+        autoPlay
+        muted/>);
+};
+
 
 export const TeamWebRTCProxyVideoWrapper = ({ url, setIsLoaded, ...props }) => {
     const dispatch = useAppDispatch();
@@ -173,6 +206,11 @@ const teamViewComponentRender: {
                 autoPlay
                 loop
                 muted/>
+        </FullWidthWrapper>;
+    },
+    M2tsVideo: ({ onLoadStatus, className, media }) => {
+        return <FullWidthWrapper className={className}>
+            <TeamM2tsVideoWrapper url={media.url} setIsLoaded={onLoadStatus}/>
         </FullWidthWrapper>;
     },
     WebRTCProxyConnection: ({ onLoadStatus, className, media }) => {

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -11,7 +11,11 @@
         "overlay",
         "admin",
         "tests"
-      ]
+      ],
+      "engines": {
+        "node": ">=20",
+        "npm": ">=10.2.4"
+      }
     },
     "admin": {
       "name": "icpc-live-v3-admin",
@@ -8744,6 +8748,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+    },
     "node_modules/esbuild": {
       "version": "0.18.11",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.11.tgz",
@@ -15070,6 +15079,15 @@
       "integrity": "sha512-5SmjNStN6bSuSE5WPT2ZV+iYn1/yI9sd4Igtk23ChvqB7kDk9lZbB9F5frsuvpB+2njdIeGGFf2G4gbE6rCC9Q==",
       "peer": true
     },
+    "node_modules/mpegts.js": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/mpegts.js/-/mpegts.js-1.7.3.tgz",
+      "integrity": "sha512-kqZ1C1IsbAQN72cK8vMrzKeM7hwrwSBbFAwVAc7PPweOeoZxCANrc7fAVDKMfYUzxdNkMTnec9tVmlxmKZB0TQ==",
+      "dependencies": {
+        "es6-promise": "^4.2.5",
+        "webworkify-webpack": "^2.1.5"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -21033,6 +21051,11 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/webworkify-webpack": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/webworkify-webpack/-/webworkify-webpack-2.1.5.tgz",
+      "integrity": "sha512-2akF8FIyUvbiBBdD+RoHpoTbHMQF2HwjcxfDvgztAX5YwbZNyrtfUMgvfgFVsgDhDPVTlkbb5vyasqDHfIDPQw=="
+    },
     "node_modules/whatwg-encoding": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
@@ -21599,6 +21622,7 @@
         "@vitejs/plugin-react": "^4.0.3",
         "lodash": "^4.17.21",
         "luxon": "^2.3.1",
+        "mpegts.js": "^1.7.3",
         "prop-types": "^15.7.2",
         "react": "^17.0.2",
         "react-components": "^0.5.1",
@@ -28294,6 +28318,11 @@
         "is-symbol": "^1.0.2"
       }
     },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+    },
     "esbuild": {
       "version": "0.18.11",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.11.tgz",
@@ -29819,7 +29848,7 @@
         "notistack": "^2.0.3",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-drag-drop-files": "2.3.4",
+        "react-drag-drop-files": "^2.3.4",
         "react-rnd": "^10.3.7",
         "react-router-dom": "^6.2.2",
         "react-scripts": "^5.0.1"
@@ -29837,6 +29866,7 @@
         "concurrently": "^8.2.2",
         "lodash": "^4.17.21",
         "luxon": "^2.3.1",
+        "mpegts.js": "^1.7.3",
         "postcss-styled-syntax": "^0.5.0",
         "prop-types": "^15.7.2",
         "react": "^17.0.2",
@@ -33437,6 +33467,15 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.44.0.tgz",
       "integrity": "sha512-5SmjNStN6bSuSE5WPT2ZV+iYn1/yI9sd4Igtk23ChvqB7kDk9lZbB9F5frsuvpB+2njdIeGGFf2G4gbE6rCC9Q==",
       "peer": true
+    },
+    "mpegts.js": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/mpegts.js/-/mpegts.js-1.7.3.tgz",
+      "integrity": "sha512-kqZ1C1IsbAQN72cK8vMrzKeM7hwrwSBbFAwVAc7PPweOeoZxCANrc7fAVDKMfYUzxdNkMTnec9tVmlxmKZB0TQ==",
+      "requires": {
+        "es6-promise": "^4.2.5",
+        "webworkify-webpack": "^2.1.5"
+      }
     },
     "ms": {
       "version": "2.1.2",
@@ -37581,6 +37620,11 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
       "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg=="
+    },
+    "webworkify-webpack": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/webworkify-webpack/-/webworkify-webpack-2.1.5.tgz",
+      "integrity": "sha512-2akF8FIyUvbiBBdD+RoHpoTbHMQF2HwjcxfDvgztAX5YwbZNyrtfUMgvfgFVsgDhDPVTlkbb5vyasqDHfIDPQw=="
     },
     "whatwg-encoding": {
       "version": "1.0.5",


### PR DESCRIPTION
This is our patch used in [The 2023 ICPC Asia East Continent Final Contest](https://icpc.global/regionals/finder/Shanghai-2024) playing teams' webcam and workstation. 

But it is based on v3.1.1. Maybe should rebase to the latest version.

[Live Stream](https://www.bilibili.com/video/BV1RT4y1n7w1/)

The m2ts videos are provided by `vlc` running on the teams' workstations. But using `mpegts` playing mt2s video on browser directly needs CORS, while we can not set this header directly by vlc.

CDS can provide a mode that proxy the request but it may require basic auth. ~~So in practice, we are running another proxy server that uses URLQuery parameters to authenticate and adds CORS header.~~ Maybe we should add basic auth header in `mpegts`'s config.

---

Update: it has been rebased to the latest version now.

