### PR TITLE
fix typo in AnalyticsGenerator

### DIFF
--- a/src/backend/src/main/kotlin/org/icpclive/service/analytics/AnalyticsGenerator.kt
+++ b/src/backend/src/main/kotlin/org/icpclive/service/analytics/AnalyticsGenerator.kt
@@ -60,7 +60,7 @@ class AnalyticsGenerator(jsonTemplatePath: Path?) {
             }
             is RunResult.ICPC -> {
                 if (runResult.isFirstToSolveRun) {
-                    messagesTemplates.firstToSolveRun.applyTemplate(substitute)
+                    return messagesTemplates.firstToSolveRun.applyTemplate(substitute)
                 } else if (runResult.verdict.isAccepted) {
                     return if (substitute["{result.solvedProblems}"] != "") {
                         messagesTemplates.acceptedWithSolvedProblemsRun.applyTemplate(substitute)


### PR DESCRIPTION
`{team.shortName} failed {problem.letter}.{problem.name} due to AC` :)