### PR TITLE
fix: IOI scoreboard should also include a ZERO score submission

### DIFF
--- a/src/cds/core/src/main/kotlin/org/icpclive/cds/scoreboard/IOIScoreboardCalculator.kt
+++ b/src/cds/core/src/main/kotlin/org/icpclive/cds/scoreboard/IOIScoreboardCalculator.kt
@@ -28,8 +28,9 @@ internal class IOIScoreboardCalculator : AbstractScoreboardCalculator() {
                     finalRun.time,
                     problemRuns.subList(0, finalRunIndex).count { (it.result as? RunResult.IOI)?.wrongVerdict?.isAddingPenalty == true })
             }
+            val scoreboardRun = finalRun ?: problemRuns.lastOrNull()
             IOIProblemResult(
-                (finalRun?.result as? RunResult.IOI?)?.scoreAfter,
+                (scoreboardRun?.result as? RunResult.IOI?)?.scoreAfter,
                 finalRun?.time,
                 (finalRun?.result as? RunResult.IOI?)?.isFirstBestRun == true
             )


### PR DESCRIPTION
There is a case where someone submitted code with a score of 0, but it is not shown on the scoreboard.