### PR TITLE
fix(queue): broken vertical featured run

### DIFF
--- a/src/frontend/overlay/src/components/organisms/widgets/Queue.tsx
+++ b/src/frontend/overlay/src/components/organisms/widgets/Queue.tsx
@@ -560,7 +560,7 @@ const QueueComponent = (VARIANT: "vertical" | "horizontal") => ({ shouldShow }: 
     const RowsContainerComponent = VARIANT === "horizontal" ? HorizontalRowsContainer : RowsContainer;
     return (
         <>
-            <HorizontalFeatured runInfo={featured}/>
+            {VARIANT === "horizontal" ? <HorizontalFeatured runInfo={featured} /> : <Featured runInfo={featured} />}
             <QueueWrap hasFeatured={!!featured} variant={VARIANT}>
                 <QueueHeader ref={(el) => (el != null) && setHeaderWidth(el.getBoundingClientRect().width)}>
                     <Title>


### PR DESCRIPTION
It was broken in 3.3.4, which may be introduced in commit c486f3398ebbe256912bcd4fdd7d375303d4b4cc. (horizontal queue feature)

**Bad:**
![image](https://github.com/user-attachments/assets/d20cb0d7-3ec5-4e2d-a994-dfab21486262)

**Good:**
![image](https://github.com/user-attachments/assets/2d52da89-983b-404e-89b1-1ce0dcff1531)


---
horizontal queue featured run still works fine after fix.

![image](https://github.com/user-attachments/assets/b01759ee-66db-4645-b448-691a89de2dbb)
